### PR TITLE
Change NS_OPTIONS to NS_ENUM to fix Swift bridging

### DIFF
--- a/LMSideBarController/LMSideBarController.h
+++ b/LMSideBarController/LMSideBarController.h
@@ -13,7 +13,7 @@
 /**
  The side bar controller direction enums.
  */
-typedef NS_OPTIONS(NSUInteger, LMSideBarControllerDirection) {
+typedef NS_ENUM(NSUInteger, LMSideBarControllerDirection) {
     LMSideBarControllerDirectionLeft,
     LMSideBarControllerDirectionRight,
 };
@@ -21,7 +21,7 @@ typedef NS_OPTIONS(NSUInteger, LMSideBarControllerDirection) {
 /**
  The side bar controller state enums.
  */
-typedef NS_OPTIONS(NSUInteger, LMSideBarControllerState) {
+typedef NS_ENUM(NSUInteger, LMSideBarControllerState) {
     LMSideBarControllerStateWillOpen,
     LMSideBarControllerStateDidOpen,
     LMSideBarControllerStateWillClose,


### PR DESCRIPTION
LMSideBarControllerDirection and LMSideBarControllerState are currently defined as NS_OPTIONS, but are used as enumerations.  When generating the Swift bridging header, we get the following:
```
public struct LMSideBarControllerDirection : OptionSet {
    public init(rawValue: UInt)
    public static var right: LMSideBarControllerDirection { get }
}
```
Note that "left" is missing.

Changing it to NS_ENUM will correctly generate the Swift enum, but will not affect the Objective-C functionality.

```
public enum LMSideBarControllerDirection : UInt {
    case left
    case right
}
```
