### PR TITLE
Improvement: removed need to set view width in storyboard

### DIFF
--- a/LMSideBarController/LMSideBarController.m
+++ b/LMSideBarController/LMSideBarController.m
@@ -154,16 +154,24 @@
     
     // Add the new one
     [self.menuViewControllers setObject:menuViewController forKey:@(direction)];
+    
+    // Get style for direction, use menuWidth as SideBar width
+    // Default to 75% view width
+    LMSideBarStyle *style = [self styleForDirection:direction];
+    CGFloat width = style.menuWidth;
+    if(width == 0){
+        width = self.view.bounds.size.width * 3.0/4.0;
+    }
     if (direction == LMSideBarControllerDirectionLeft) {
-        [self setupViewController:menuViewController frame:CGRectMake(-self.view.bounds.size.width,
+        [self setupViewController:menuViewController frame:CGRectMake(-width,
                                                                       0,
-                                                                      self.view.bounds.size.width,
+                                                                      width,
                                                                       self.view.bounds.size.height)];
     }
     else {
         [self setupViewController:menuViewController frame:CGRectMake(self.view.bounds.size.width,
                                                                       0,
-                                                                      self.view.bounds.size.width,
+                                                                      width,
                                                                       self.view.bounds.size.height)];
     }
     menuViewController.view.hidden = YES;


### PR DESCRIPTION
Added code to setMenuViewController to set the VC frame width from the SideBarStyle.menuWidth.

Default to 75% screen width if style not set.
Requires call to setSideBarStyle before setMenuViewController, but no longer requries view width to be set in storyboard